### PR TITLE
Fix route tree generation watch loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 
 .env
+src/generated

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "vite build && tsc -b",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import "./index.css";
 
 export const queryClient = new QueryClient();
 
-import { routeTree } from "./routeTree.gen";
+import { routeTree } from "./generated/routeTree.gen";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "./components/theme-provider";

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -25,5 +25,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "src/generated"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,12 @@ import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), TanStackRouterVite()],
+  plugins: [
+    react(),
+    TanStackRouterVite({
+      generatedRouteTree: './src/generated/routeTree.gen.ts',
+    }),
+  ],
   define: {
     "process.env": {},
   },


### PR DESCRIPTION
## Summary
- ignore new generated folder
- configure TanStack Router plugin to output to `src/generated`
- update import for generated route tree
- include new folder in TypeScript config
- run Vite build before TypeScript compilation to ensure generation

## Testing
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_686d66c38498832ebe16d075eeaf6ae9