### PR TITLE
Toggle layout padding with navbar

### DIFF
--- a/src/views/Layout.tsx
+++ b/src/views/Layout.tsx
@@ -1,11 +1,27 @@
 import Navbar from "./Navbar";
 import { Outlet } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
 
 export default function Layout() {
+  const [navVisible, setNavVisible] = useState(true);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.altKey && e.code === "KeyF") {
+        e.preventDefault();
+        setNavVisible((v) => !v);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   return (
     <div className="flex h-full w-full flex-col p-1">
-      <Navbar />
-      <div className="h-full w-full p-3 pt-1">
+      <Navbar visible={navVisible} />
+      <div className={cn("h-full w-full", navVisible && "p-3 pt-1")}>
         <div className="flex h-full flex-row justify-center gap-8 overflow-clip rounded-xl border-2 border-black bg-gray-200/60 dark:border-white dark:bg-gray-900">
           <Outlet />
         </div>

--- a/src/views/Navbar.tsx
+++ b/src/views/Navbar.tsx
@@ -3,7 +3,10 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Link } from "@tanstack/react-router";
 import { LucideIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+
+type NavbarProps = {
+  visible: boolean;
+};
 
 type NavButtonProps = {
   isActive: boolean;
@@ -36,20 +39,7 @@ const routes = [
   },
 ];
 
-export default function Navbar() {
-  const [visible, setVisible] = useState(true);
-
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.altKey && e.code === "KeyF") {
-        e.preventDefault();
-        setVisible((v) => !v);
-      }
-    }
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, []);
+export default function Navbar({ visible }: NavbarProps) {
 
   return (
     <nav


### PR DESCRIPTION
## Summary
- pass visibility state into `Navbar` instead of internal state
- toggle layout padding when hiding the navbar

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e72f87ba8832e8851338456d68a2f